### PR TITLE
fix: apply keys to value for translations with config `useKey`

### DIFF
--- a/proc/render-excel.mjs
+++ b/proc/render-excel.mjs
@@ -49,9 +49,10 @@ export default (base = process.cwd(), path = '', tabName = '', conf = {SkipRows:
             let cellName = `${colName}${rowName}`;
             let cell     = sheet[cellName] || {};
             let cellVal  = UtilFormat.transText(cell.v || '');
+            let cellText = cellVal || (mapperConf.useKey ? transKey : '');
             let langCode = mapperConf.langCode || '';
 
-            _.set(translations, [langCode, transKey], cellVal);
+            _.set(translations, [langCode, transKey], cellText);
         }
     }
 


### PR DESCRIPTION
Apply keys to value for translations with config `useKey`

----

There is a mapper setting for Chinese (Simplified) with `useKey: true`:
```js
const KeyMapper = {
    E: {
        langName: '中文（简体）',
        langCode: 'zh-CN',
        useKey: true
    }
};
```

Since the generated JSONs are previously used by Unity Map Application, and the application uses keys as values if the value is absent. However, this is not compatiable for most i18n engines.

This fix makes the generated json compatiable for i18n engines, by use keys as values if `useKey` is set to `true` and the value is absent.

For example: (with `useKey: true`)

Former:
```json
{
    "登录遇到问题？": ""
}
```

Fixed to:
```json
{
    "登录遇到问题？": "登录遇到问题？"
}
```